### PR TITLE
(patch) On safari `_updateViewSize` does not run on page load

### DIFF
--- a/cosmoz-viewinfo.js
+++ b/cosmoz-viewinfo.js
@@ -122,6 +122,7 @@
 		connectedCallback() {
 			super.connectedCallback();
 			this.addEventListener('iron-resize', this._boundOnResize);
+			this._onResize();
 		}
 
 		disconnectedCallback() {


### PR DESCRIPTION
Ensure that `_updateViewSize` is run at least once.

Fixes #14