### PR TITLE
feat(context): export ViewInfo Context for haunted components

### DIFF
--- a/cosmoz-viewinfo.js
+++ b/cosmoz-viewinfo.js
@@ -8,7 +8,13 @@ import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class';
 
 import { VIEW_INFO_INSTANCES, SHARED_VIEW_INFO } from './cosmoz-viewinfo-mixin';
 
+import { createContext } from 'haunted';
+
 export { viewInfoAware } from './cosmoz-viewinfo-mixin';
+
+export const ViewInfo = createContext(SHARED_VIEW_INFO);
+
+customElements.define('view-info-provider', ViewInfo.Provider);
 
 /**
  * `<cosmoz-viewinfo>` is a component to create a view with information about
@@ -22,7 +28,7 @@ export { viewInfoAware } from './cosmoz-viewinfo-mixin';
  */
 export class CosmozViewInfo extends mixinBehaviors([IronResizableBehavior], PolymerElement) {
 	static get template() {
-		return html`<slot></slot>`;
+		return html`<view-info-provider value="[[ _currentViewInfo ]]"><slot></slot></view-info-provider>`;
 	}
 
 	/**
@@ -71,6 +77,10 @@ export class CosmozViewInfo extends mixinBehaviors([IronResizableBehavior], Poly
 			throttleTimeout: {
 				type: Number,
 				value: 250
+			},
+			_currentViewInfo: {
+				type: Object,
+				value: SHARED_VIEW_INFO
 			}
 		};
 	}
@@ -167,7 +177,7 @@ export class CosmozViewInfo extends mixinBehaviors([IronResizableBehavior], Poly
 	 * @returns {boolean}  returns true if SHARED_VIEW_INFO.width is lower the
 	 * next width
 	 */
-	_updateViewSize() {
+	_updateViewSize() { // eslint-disable-line max-statements
 		const
 			prevWidth = SHARED_VIEW_INFO.width,
 			next = {
@@ -196,6 +206,8 @@ export class CosmozViewInfo extends mixinBehaviors([IronResizableBehavior], Poly
 		Object.keys(delta).forEach(key => {
 			SHARED_VIEW_INFO[key] = delta[key];
 		});
+
+		this._currentViewInfo = {...SHARED_VIEW_INFO};
 
 		this._notifyInstances(delta);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4468,6 +4468,14 @@
 				}
 			}
 		},
+		"haunted": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/haunted/-/haunted-4.7.0.tgz",
+			"integrity": "sha512-ajsUengbSL2ELljJ2VLU2o5BfG/drzZV+BvSLALvIBx+24owmxC5iW7+SK/Y667JaVmratEPR010bYpGKAt7ow==",
+			"requires": {
+				"lit-html": "^1.0.0"
+			}
+		},
 		"he": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
@@ -5269,6 +5277,11 @@
 			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
 			"integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
 			"dev": true
+		},
+		"lit-html": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.2.1.tgz",
+			"integrity": "sha512-GSJHHXMGLZDzTRq59IUfL9FCdAlGfqNp/dEa7k7aBaaWD+JKaCjsAk9KYm2V12ItonVaYx2dprN66Zdm1AuBTQ=="
 		},
 		"load-json-file": {
 			"version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
 	},
 	"dependencies": {
 		"@polymer/iron-resizable-behavior": "^3.0.0",
-		"@polymer/polymer": "^3.2.0"
+		"@polymer/polymer": "^3.2.0",
+		"haunted": "^4.7.0"
 	},
 	"devDependencies": {
 		"@commitlint/cli": "^8.2.0",


### PR DESCRIPTION
Usage example:
```js
import { ViewInfo } from '@neovici/cosmoz-viewinfo';
...
viewInfo = useContext(ViewInfo)
console.log(viewInfo.mobile)
```